### PR TITLE
Align behaviour with ECMAScript

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,8 +10,11 @@ go get github.com/xnacly/go-iso8601-duration
 
 ## Features
 
-- ISO8601 duration parsing formats: `P[nn]Y[nn]M[nn]DT[nn]H[nn]M[nn]S` or
-  `P[nn]W` via `goiso8601duration.From`
+- ISO8601 duration parsing formats: `[+-]P[n]Y[n]W[n]M[n]DT[n]H[n]M[n]S` via
+  `goiso8601duration.From`:
+    - aligned with [ECMAScript: Temporal - 7 Temporal.Duration
+      Objects](https://tc39.es/proposal-temporal/#sec-temporal-duration-objects)
+      and ISO8601
 - Interop with [`time.Time`](https://pkg.go.dev/time#Time) and
   [`time.Duration`](https://pkg.go.dev/time#Duration) via:
   - `goiso8601duration.Duration.Apply(time.Time) time.Time`
@@ -23,14 +26,6 @@ go get github.com/xnacly/go-iso8601-duration
   [`json.Unmarshaller`](https://pkg.go.dev/encoding/json#Unmarshaler) and
   [`json.Marshaller`](https://pkg.go.dev/encoding/json#Marshaler)
 - High quality errors with position context.
-
-## Non features
-
-> I am open to implement these, if someone needs them
-
-- Negative durations `(-P1Y)` -> because I don't have access to the newest spec, so I have no idea what it specifies
-- Fractional seconds `(PT1.5S)` -> technically this can be supported for the last / smallest unit, but I dont think its necessary
-- Arbitrary digit lengths -> spec says two digits is fine, so I'll keep it like that
 
 ## Example
 

--- a/duration.go
+++ b/duration.go
@@ -44,7 +44,7 @@ const (
 
 	// seen n
 	stateNumber
-	// seen [Y], [M], [D]
+	// seen [Y], [W], [M], [D]
 	stateDesignator
 
 	// start of Time: is used as time designator to indicate: the start of the representation of the number of hours, minutes or seconds in expressions of duration
@@ -222,8 +222,8 @@ func From(s string) (Duration, error) {
 					}
 					duration.month = float64(num)
 				case 'W':
-					if r.Len() != 0 {
-						return duration, wrapErr(NoDesignatorsAfterWeeksAllowed, col)
+					if duration.week != 0 {
+						return duration, wrapErr(DuplicateDesignator, col)
 					}
 					duration.week = float64(num)
 				case 'D':
@@ -337,12 +337,6 @@ func (i Duration) String() string {
 		return b.String()
 	}
 
-	if i.week > 0 {
-		b.WriteString(strconv.FormatFloat(i.week, 'g', -1, 64))
-		b.WriteByte('W')
-		return b.String()
-	}
-
 	if i.year > 0 {
 		b.WriteString(strconv.FormatFloat(i.year, 'g', -1, 64))
 		b.WriteByte('Y')
@@ -350,6 +344,10 @@ func (i Duration) String() string {
 	if i.month > 0 {
 		b.WriteString(strconv.FormatFloat(i.month, 'g', -1, 64))
 		b.WriteByte('M')
+	}
+	if i.week > 0 {
+		b.WriteString(strconv.FormatFloat(i.week, 'g', -1, 64))
+		b.WriteByte('W')
 	}
 	if i.day > 0 {
 		b.WriteString(strconv.FormatFloat(i.day, 'g', -1, 64))

--- a/duration_test.go
+++ b/duration_test.go
@@ -63,6 +63,7 @@ var testcases = []struct {
 }{
 	{"P0D", Duration{}},
 	{"PT15H", Duration{hour: 15}},
+	{"PT15H", Duration{hour: 15}},
 	{"P1W", Duration{week: 1}},
 	{"P15W", Duration{week: 15}},
 	{"P15Y", Duration{year: 15}},
@@ -160,6 +161,17 @@ func TestDurationRoundtrip(t *testing.T) {
 			asTimeDuration := tc.dur.Duration()
 			asDur := FromDuration(asTimeDuration)
 			assert.Equal(t, asTimeDuration, asDur.Duration())
+		})
+	}
+}
+
+func TestDurationNegativeSign(t *testing.T) {
+	for _, tc := range testcases {
+		t.Run(tc.str, func(t *testing.T) {
+			s := "-" + tc.str
+			parsed, err := From(s)
+			assert.NoError(t, err)
+			assert.Equal(t, -tc.dur.Duration(), parsed.Duration())
 		})
 	}
 }

--- a/duration_test.go
+++ b/duration_test.go
@@ -126,8 +126,8 @@ func TestDurationErr(t *testing.T) {
 		"P1A",     // UnknownDesignator
 		"P12D12D", // DuplicateDesignator
 		"P1YD",    // MissingNumber
-		"P111Y",   // TooManyNumbersForDesignator
-		"Z",       // MissingPDesignatorAtStart
+		"P1111111111111111111111111111111111111Y", // DesignatorNumberTooLarge
+		"Z", // MissingPDesignatorAtStart
 	}
 
 	for _, i := range cases {

--- a/duration_test.go
+++ b/duration_test.go
@@ -175,3 +175,14 @@ func TestDurationNegativeSign(t *testing.T) {
 		})
 	}
 }
+
+func TestDurationExplicitPositiveSign(t *testing.T) {
+	for _, tc := range testcases {
+		t.Run(tc.str, func(t *testing.T) {
+			s := "+" + tc.str
+			parsed, err := From(s)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.dur.Duration(), parsed.Duration())
+		})
+	}
+}

--- a/duration_test.go
+++ b/duration_test.go
@@ -66,6 +66,7 @@ var testcases = []struct {
 	{"PT15H", Duration{hour: 15}},
 	{"P1W", Duration{week: 1}},
 	{"P15W", Duration{week: 15}},
+	{"P1Y15W", Duration{year: 1, week: 15}},
 	{"P15Y", Duration{year: 15}},
 	{"P15Y3M", Duration{year: 15, month: 3}},
 	{"P15Y3M41D", Duration{year: 15, month: 3, day: 41}},
@@ -127,7 +128,6 @@ func TestDurationErr(t *testing.T) {
 		"P1YD",    // MissingNumber
 		"P111Y",   // TooManyNumbersForDesignator
 		"Z",       // MissingPDesignatorAtStart
-		"P15W2D",  // NoDesignatorsAfterWeeksAllowed
 	}
 
 	for _, i := range cases {

--- a/error.go
+++ b/error.go
@@ -6,15 +6,15 @@ import (
 )
 
 var (
-	UnexpectedEof               = errors.New("Unexpected EOF in duration format string")
-	UnexpectedReaderError       = errors.New("Failed to retrieve next byte of duration format string")
-	UnexpectedNonAsciiRune      = errors.New("Unexpected non ascii component in duration format string")
-	MissingDesignator           = errors.New("Missing unit designator")
-	UnknownDesignator           = errors.New("Unknown designator, expected YMWD or after a T, HMS")
-	DuplicateDesignator         = errors.New("Duplicate designator")
-	MissingNumber               = errors.New("Missing number specifier before unit designator")
-	TooManyNumbersForDesignator = errors.New("Only 2 numbers before any designator allowed")
-	MissingPDesignatorAtStart   = errors.New("Missing [P] designator at the start of the duration format string")
+	UnexpectedEof             = errors.New("Unexpected EOF in duration format string")
+	UnexpectedReaderError     = errors.New("Failed to retrieve next byte of duration format string")
+	UnexpectedNonAsciiRune    = errors.New("Unexpected non ascii component in duration format string")
+	MissingDesignator         = errors.New("Missing unit designator")
+	UnknownDesignator         = errors.New("Unknown designator, expected YMWD or after a T, HMS")
+	DuplicateDesignator       = errors.New("Duplicate designator")
+	MissingNumber             = errors.New("Missing number specifier before unit designator")
+	DesignatorNumberTooLarge  = errors.New("The number for the designator is too large for int64")
+	MissingPDesignatorAtStart = errors.New("Missing [P] designator at the start of the duration format string")
 )
 
 type ISO8601DurationError struct {

--- a/error.go
+++ b/error.go
@@ -6,16 +6,15 @@ import (
 )
 
 var (
-	UnexpectedEof                  = errors.New("Unexpected EOF in duration format string")
-	UnexpectedReaderError          = errors.New("Failed to retrieve next byte of duration format string")
-	UnexpectedNonAsciiRune         = errors.New("Unexpected non ascii component in duration format string")
-	MissingDesignator              = errors.New("Missing unit designator")
-	UnknownDesignator              = errors.New("Unknown designator, expected YMWD or after a T, HMS")
-	DuplicateDesignator            = errors.New("Duplicate designator")
-	MissingNumber                  = errors.New("Missing number specifier before unit designator")
-	TooManyNumbersForDesignator    = errors.New("Only 2 numbers before any designator allowed")
-	MissingPDesignatorAtStart      = errors.New("Missing [P] designator at the start of the duration format string")
-	NoDesignatorsAfterWeeksAllowed = errors.New("After [W] designator, no other numbers and designators are allowed")
+	UnexpectedEof               = errors.New("Unexpected EOF in duration format string")
+	UnexpectedReaderError       = errors.New("Failed to retrieve next byte of duration format string")
+	UnexpectedNonAsciiRune      = errors.New("Unexpected non ascii component in duration format string")
+	MissingDesignator           = errors.New("Missing unit designator")
+	UnknownDesignator           = errors.New("Unknown designator, expected YMWD or after a T, HMS")
+	DuplicateDesignator         = errors.New("Duplicate designator")
+	MissingNumber               = errors.New("Missing number specifier before unit designator")
+	TooManyNumbersForDesignator = errors.New("Only 2 numbers before any designator allowed")
+	MissingPDesignatorAtStart   = errors.New("Missing [P] designator at the start of the duration format string")
 )
 
 type ISO8601DurationError struct {


### PR DESCRIPTION
- [x] DurationSign: either + or -
- [x] W and all other date designators are not exclusive
- [x] allow full int64 size in each designator pair

From #1:

> See [Temporal - 7 Temporal.Duration Objects](https://tc39.es/proposal-temporal/#sec-temporal-duration-objects), more specific in [7.5.12 ToTermporalDuration](https://tc39.es/proposal-temporal/#sec-temporal-totemporalduration), which differs from this impl as follows:
> 
> 1. `DurationSign`: either `+` or `-`
> 2. `W` and all other date designators are not exclusive
> 3. Allow full int64 size in each designator pair
> 
> Aligining this would make sense to allow for roundtripping with the new temporal api and this library, both for serialisation and deserialisation.