### PR TITLE
Performance improvements

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,3 +22,6 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+    - name: Benchmark
+      run: go test -bench=. -benchmem

--- a/Readme.md
+++ b/Readme.md
@@ -94,4 +94,21 @@ Reproduce with:
 
 ```text
 go test -bench=. -benchmem
+goos: linux
+goarch: amd64
+pkg: github.com/xnacly/go-iso8601-duration
+cpu: AMD Ryzen 7 3700X 8-Core Processor
+BenchmarkDuration/P0D-16                100000000               10.51 ns/op            0 B/op          0 allocs/op
+BenchmarkDuration/PT15H-16              80446293                14.58 ns/op            0 B/op          0 allocs/op
+BenchmarkDuration/P1W-16                100000000               10.33 ns/op            0 B/op          0 allocs/op
+BenchmarkDuration/P15W-16               93517448                12.75 ns/op            0 B/op          0 allocs/op
+BenchmarkDuration/P1Y15W-16             70472916                17.19 ns/op            0 B/op          0 allocs/op
+BenchmarkDuration/P15Y-16               89461000                12.75 ns/op            0 B/op          0 allocs/op
+BenchmarkDuration/P15Y3M-16             61222558                18.65 ns/op            0 B/op          0 allocs/op
+BenchmarkDuration/P15Y3M41D-16          46391493                25.45 ns/op            0 B/op          0 allocs/op
+BenchmarkDuration/PT15M-16              80630947                14.98 ns/op            0 B/op          0 allocs/op
+BenchmarkDuration/PT15M10S-16           55008163                22.14 ns/op            0 B/op          0 allocs/op
+BenchmarkDuration/P3Y6M4DT12H30M5S-16   24965916                46.99 ns/op            0 B/op          0 allocs/op
+PASS
+ok      github.com/xnacly/go-iso8601-duration   12.956s
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Go ISO8601 Duration
 
-A small libary for parsing
+A small, zero alloc and high performance libary for parsing
 [ISO8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) compliant duration
 format into Go time compatible representation.
 
@@ -86,4 +86,12 @@ func main() {
 	// {In:PT12M43S}
 	fmt.Printf("%+v\n", a)
 }
+```
+
+## Benchmarks
+
+Reproduce with:
+
+```text
+go test -bench=. -benchmem
 ```

--- a/duration.go
+++ b/duration.go
@@ -2,11 +2,11 @@ package goiso8601duration
 
 import (
 	"encoding/json"
-	"io"
 	"math"
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 )
 
 // constants for roundtripping between time.Duration and Duration
@@ -112,33 +112,13 @@ func From(s string) (Duration, error) {
 	}
 
 	curState := stateStart
-	var col uint8
 	var num int64
 	var hasNum bool
-	r := strings.NewReader(s)
 
-	for {
-		b, size, err := r.ReadRune()
-		if err != nil {
-			if err != io.EOF {
-				return duration, wrapErr(UnexpectedReaderError, col)
-			} else if curState == stateP {
-				// being in stateP at the end (io.EOF) means we havent
-				// encountered anything after the P, so there were no numbers
-				// or states
-				return duration, wrapErr(UnexpectedEof, col)
-			} else if curState == stateNumber || curState == stateTNumber {
-				// if we are in the state of Number or TNumber we had a number
-				// but no designator at the end
-				return duration, wrapErr(MissingDesignator, col)
-			} else {
-				curState = stateFin
-			}
-		}
-		if size > 1 {
+	for col, b := range s {
+		if b > unicode.MaxASCII {
 			return duration, wrapErr(UnexpectedNonAsciiRune, col)
 		}
-		col++
 
 		switch curState {
 		case stateStart:
@@ -253,6 +233,19 @@ func From(s string) (Duration, error) {
 		case stateFin:
 			return duration, nil
 		}
+	}
+
+	if curState == stateP {
+		// being in stateP at the end (io.EOF) means we havent
+		// encountered anything after the P, so there were no numbers
+		// or states
+		return duration, wrapErr(UnexpectedEof, len(s))
+	} else if curState == stateNumber || curState == stateTNumber {
+		// if we are in the state of Number or TNumber we had a number
+		// but no designator at the end
+		return duration, wrapErr(MissingDesignator, len(s))
+	} else {
+		return duration, nil
 	}
 }
 

--- a/duration.go
+++ b/duration.go
@@ -1,7 +1,6 @@
 package goiso8601duration
 
 import (
-	"bytes"
 	"encoding/json"
 	"io"
 	"math"
@@ -91,19 +90,6 @@ func FromDuration(d time.Duration) Duration {
 	duration.second = int64(float64(ns) / float64(nsPerSecond))
 
 	return duration
-}
-
-func numBufferToNumber(buf bytes.Buffer) (int64, error) {
-	var i int64
-	for _, n := range buf.Bytes() {
-		digit := int64(n - '0')
-		if i > (math.MaxInt64-digit)/10 {
-			return 0, DesignatorNumberTooLarge
-		}
-		i = (i * 10) + digit
-	}
-
-	return i, nil
 }
 
 // P[nn]Y[nn]M[nn]DT[nn]H[nn]M[nn]S or P[nn]W, as seen in

--- a/duration.go
+++ b/duration.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
 )
 
 // constants for roundtripping between time.Duration and Duration
@@ -157,7 +156,7 @@ func From(s string) (Duration, error) {
 		case stateP, stateDesignator:
 			if b == 'T' {
 				curState = stateT
-			} else if unicode.IsDigit(b) {
+			} else if '0' <= b && b <= '9' {
 				num = (num * 10) + int64(b-'0')
 				hasNum = true
 				curState = stateNumber
@@ -165,7 +164,7 @@ func From(s string) (Duration, error) {
 				return duration, wrapErr(MissingNumber, col)
 			}
 		case stateNumber:
-			if unicode.IsDigit(b) {
+			if '0' <= b && b <= '9' {
 				digit := int64(b - '0')
 				if num > (math.MaxInt64-digit)/10 {
 					return duration, DesignatorNumberTooLarge
@@ -205,7 +204,7 @@ func From(s string) (Duration, error) {
 				return duration, wrapErr(UnknownDesignator, col)
 			}
 		case stateT, stateTDesignator:
-			if unicode.IsDigit(b) {
+			if '0' <= b && b <= '9' {
 				digit := int64(b - '0')
 				if num > (math.MaxInt64-digit)/10 {
 					return duration, DesignatorNumberTooLarge
@@ -217,7 +216,7 @@ func From(s string) (Duration, error) {
 				return duration, wrapErr(MissingNumber, col)
 			}
 		case stateTNumber:
-			if unicode.IsDigit(b) {
+			if '0' <= b && b <= '9' {
 				digit := int64(b - '0')
 				if num > (math.MaxInt64-digit)/10 {
 					return duration, DesignatorNumberTooLarge

--- a/duration.go
+++ b/duration.go
@@ -23,16 +23,6 @@ const (
 // From is a FSM, see https://en.wikipedia.org/wiki/Finite-state_machine
 type state = uint8
 
-// In representations of duration,
-// the following designators are used as part of the expression,
-// see the doc comment of the function
-//
-// [Y] [M] [W] [D] [H] [M] [S]
-const (
-	defaultDesignators = "YMWD"
-	timeDesignators    = "MHS"
-)
-
 const (
 	stateStart state = iota
 	// start of duration: is used as duration designator, preceding the component which represents the duration;
@@ -152,7 +142,7 @@ func From(s string) (Duration, error) {
 				num = (num * 10) + digit
 				hasNum = true
 				curState = stateNumber
-			} else if strings.ContainsRune(defaultDesignators, b) {
+			} else {
 				if !hasNum {
 					return duration, wrapErr(MissingNumber, col)
 				}
@@ -177,11 +167,12 @@ func From(s string) (Duration, error) {
 						return duration, wrapErr(DuplicateDesignator, col)
 					}
 					duration.day = num
+				default:
+
+					return duration, wrapErr(UnknownDesignator, col)
 				}
 				num = 0
 				curState = stateDesignator
-			} else {
-				return duration, wrapErr(UnknownDesignator, col)
 			}
 		case stateT, stateTDesignator:
 			if '0' <= b && b <= '9' {
@@ -204,7 +195,7 @@ func From(s string) (Duration, error) {
 				num = (num * 10) + digit
 				hasNum = true
 				curState = stateTNumber
-			} else if strings.ContainsRune(timeDesignators, b) {
+			} else {
 				if !hasNum {
 					return duration, wrapErr(MissingNumber, col)
 				}
@@ -224,11 +215,12 @@ func From(s string) (Duration, error) {
 						return duration, wrapErr(DuplicateDesignator, col)
 					}
 					duration.second = num
+				default:
+
+					return duration, wrapErr(UnknownDesignator, col)
 				}
 				num = 0
 				curState = stateTDesignator
-			} else {
-				return duration, wrapErr(UnknownDesignator, col)
 			}
 		case stateFin:
 			return duration, nil

--- a/duration.go
+++ b/duration.go
@@ -128,7 +128,8 @@ func From(s string) (Duration, error) {
 
 	curState := stateStart
 	var col uint8
-	numBuf := *bytes.NewBuffer(make([]byte, 0, 8))
+	var num int64
+	var hasNum bool
 	r := strings.NewReader(s)
 
 	for {
@@ -171,22 +172,24 @@ func From(s string) (Duration, error) {
 			if b == 'T' {
 				curState = stateT
 			} else if unicode.IsDigit(b) {
-				numBuf.WriteRune(b)
+				num = (num * 10) + int64(b-'0')
+				hasNum = true
 				curState = stateNumber
 			} else {
 				return duration, wrapErr(MissingNumber, col)
 			}
 		case stateNumber:
 			if unicode.IsDigit(b) {
-				numBuf.WriteRune(b)
+				digit := int64(b - '0')
+				if num > (math.MaxInt64-digit)/10 {
+					return duration, DesignatorNumberTooLarge
+				}
+				num = (num * 10) + digit
+				hasNum = true
 				curState = stateNumber
 			} else if strings.ContainsRune(defaultDesignators, b) {
-				if numBuf.Len() == 0 {
+				if !hasNum {
 					return duration, wrapErr(MissingNumber, col)
-				}
-				num, err := numBufferToNumber(numBuf)
-				if err != nil {
-					return duration, err
 				}
 				switch b {
 				case 'Y':
@@ -210,29 +213,35 @@ func From(s string) (Duration, error) {
 					}
 					duration.day = num
 				}
-				numBuf.Reset()
+				num = 0
 				curState = stateDesignator
 			} else {
 				return duration, wrapErr(UnknownDesignator, col)
 			}
 		case stateT, stateTDesignator:
 			if unicode.IsDigit(b) {
-				numBuf.WriteRune(b)
+				digit := int64(b - '0')
+				if num > (math.MaxInt64-digit)/10 {
+					return duration, DesignatorNumberTooLarge
+				}
+				num = (num * 10) + digit
+				hasNum = true
 				curState = stateTNumber
 			} else {
 				return duration, wrapErr(MissingNumber, col)
 			}
 		case stateTNumber:
 			if unicode.IsDigit(b) {
-				numBuf.WriteRune(b)
+				digit := int64(b - '0')
+				if num > (math.MaxInt64-digit)/10 {
+					return duration, DesignatorNumberTooLarge
+				}
+				num = (num * 10) + digit
+				hasNum = true
 				curState = stateTNumber
 			} else if strings.ContainsRune(timeDesignators, b) {
-				if numBuf.Len() == 0 {
+				if !hasNum {
 					return duration, wrapErr(MissingNumber, col)
-				}
-				num, err := numBufferToNumber(numBuf)
-				if err != nil {
-					return duration, err
 				}
 				switch b {
 				case 'H':
@@ -251,7 +260,7 @@ func From(s string) (Duration, error) {
 					}
 					duration.second = num
 				}
-				numBuf.Reset()
+				num = 0
 				curState = stateTDesignator
 			} else {
 				return duration, wrapErr(UnknownDesignator, col)

--- a/error.go
+++ b/error.go
@@ -7,7 +7,6 @@ import (
 
 var (
 	UnexpectedEof             = errors.New("Unexpected EOF in duration format string")
-	UnexpectedReaderError     = errors.New("Failed to retrieve next byte of duration format string")
 	UnexpectedNonAsciiRune    = errors.New("Unexpected non ascii component in duration format string")
 	MissingDesignator         = errors.New("Missing unit designator")
 	UnknownDesignator         = errors.New("Unknown designator, expected YMWD or after a T, HMS")
@@ -19,10 +18,10 @@ var (
 
 type ISO8601DurationError struct {
 	Inner  error
-	Column uint8
+	Column int
 }
 
-func wrapErr(inner error, col uint8) error {
+func wrapErr(inner error, col int) error {
 	return ISO8601DurationError{
 		Inner:  inner,
 		Column: col,


### PR DESCRIPTION
| Benchmark        | Baseline (ns) | Improved (ns) | delta (ns) | % Faster | Speedup (x) |
| ---------------- | ------------- | ------------- | ---------- | -------- | ----------- |
| P0D              | 64.26         | 10.51         | -53.75     | 83.6%    | 6.11x       |
| PT15H            | 76.69         | 14.58         | -62.11     | 81.0%    | 5.26x       |
| P1W              | 64.10         | 10.33         | -53.77     | 83.9%    | 6.21x       |
| P15W             | 74.35         | 12.75         | -61.60     | 82.9%    | 5.83x       |
| P1Y15W           | 95.39         | 17.19         | -78.20     | 82.0%    | 5.55x       |
| P15Y             | 74.44         | 12.75         | -61.69     | 82.9%    | 5.84x       |
| P15Y3M           | 96.33         | 18.65         | -77.68     | 80.7%    | 5.16x       |
| P15Y3M41D        | 123.7         | 25.45         | -98.25     | 79.4%    | 4.86x       |
| PT15M            | 76.61         | 14.98         | -61.63     | 80.4%    | 5.11x       |
| PT15M10S         | 104.8         | 22.14         | -82.66     | 78.9%    | 4.73x       |
| P3Y6M4DT12H30M5S | 188.7         | 46.99         | -141.71    | 75.1%    | 4.02x       |


Closes #5 and afterwards Closes #4.

(Shouldve also included 0776adb1312fdb82c687cd8ec247698baba4acae)

## After improvements:

```text
goos: linux
goarch: amd64
pkg: github.com/xnacly/go-iso8601-duration
cpu: AMD Ryzen 7 3700X 8-Core Processor
BenchmarkDuration/P0D-16                100000000               10.51 ns/op            0 B/op          0 allocs/op
BenchmarkDuration/PT15H-16              80446293                14.58 ns/op            0 B/op          0 allocs/op
BenchmarkDuration/P1W-16                100000000               10.33 ns/op            0 B/op          0 allocs/op
BenchmarkDuration/P15W-16               93517448                12.75 ns/op            0 B/op          0 allocs/op
BenchmarkDuration/P1Y15W-16             70472916                17.19 ns/op            0 B/op          0 allocs/op
BenchmarkDuration/P15Y-16               89461000                12.75 ns/op            0 B/op          0 allocs/op
BenchmarkDuration/P15Y3M-16             61222558                18.65 ns/op            0 B/op          0 allocs/op
BenchmarkDuration/P15Y3M41D-16          46391493                25.45 ns/op            0 B/op          0 allocs/op
BenchmarkDuration/PT15M-16              80630947                14.98 ns/op            0 B/op          0 allocs/op
BenchmarkDuration/PT15M10S-16           55008163                22.14 ns/op            0 B/op          0 allocs/op
BenchmarkDuration/P3Y6M4DT12H30M5S-16   24965916                46.99 ns/op            0 B/op          0 allocs/op
PASS
ok      github.com/xnacly/go-iso8601-duration   12.956s
```

## Baseline

```text
goos: linux
goarch: amd64
pkg: github.com/xnacly/go-iso8601-duration
cpu: AMD Ryzen 7 3700X 8-Core Processor
BenchmarkDuration/P0D-16                18941151                64.26 ns/op           64 B/op          1 allocs/op
BenchmarkDuration/PT15H-16              15597309                76.69 ns/op           64 B/op          1 allocs/op
BenchmarkDuration/P1W-16                18366788                64.10 ns/op           64 B/op          1 allocs/op
BenchmarkDuration/P15W-16               15964773                74.35 ns/op           64 B/op          1 allocs/op
BenchmarkDuration/P1Y15W-16             12367951                95.39 ns/op           64 B/op          1 allocs/op
BenchmarkDuration/P15Y-16               15903548                74.44 ns/op           64 B/op          1 allocs/op
BenchmarkDuration/P15Y3M-16             12397192                96.33 ns/op           64 B/op          1 allocs/op
BenchmarkDuration/P15Y3M41D-16          9608250                 123.7 ns/op           64 B/op          1 allocs/op
BenchmarkDuration/PT15M-16              15343340                76.61 ns/op           64 B/op          1 allocs/op
BenchmarkDuration/PT15M10S-16           11336277                104.8 ns/op           64 B/op          1 allocs/op
BenchmarkDuration/P3Y6M4DT12H30M5S-16   6286371                 188.7 ns/op           64 B/op          1 allocs/op
PASS
ok      github.com/xnacly/go-iso8601-duration   14.159s
```
